### PR TITLE
Default Core Data Repository 구현

### DIFF
--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -26,8 +26,12 @@ struct DefaultCoreDataRepository: CoreDataRepository {
         return container
     }()
     
-    private var context: NSManagedObjectContext {
-        return persistentContainer.viewContext
+    private let context: NSManagedObjectContext
+    
+    init() {
+        let context = persistentContainer.viewContext
+        context.automaticallyMergesChangesFromParent = true
+        self.context = context
     }
     
     func create(_ domain: Motion) throws {

--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -5,4 +5,43 @@
 //  Created by Ayaan, Wonbi on 2023/01/31.
 //
 
-import Foundation
+import CoreData
+
+enum CoreDataError: Error {
+    case invalidEntity
+}
+
+struct DefaultCoreDataRepository: CoreDataRepository {
+    typealias Domain = Motion
+    typealias Entity = MotionMO
+    
+    private let persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "GyroData")
+        container.loadPersistentStores(completionHandler: { (_, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    private var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    func create(_ domain: Motion) throws {
+        
+    }
+    
+    func read(from offset: Int) throws -> [MotionMO] {
+        return []
+    }
+    
+    func read(with id: String) throws -> MotionMO {
+        return MotionMO(context: context)
+    }
+    
+    func delete(_ id: String) throws {
+        
+    }
+}

--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -30,7 +30,24 @@ struct DefaultCoreDataRepository: CoreDataRepository {
     }
     
     func create(_ domain: Motion) throws {
+        guard let entity = NSEntityDescription.entity(
+            forEntityName: "MotionMO",
+            in: context
+        ) else {
+            throw CoreDataError.invalidEntity
+        }
         
+        let motionMO = NSManagedObject(entity: entity, insertInto: context)
+        
+        motionMO.setValue(domain.id, forKey: "id")
+        motionMO.setValue(domain.date.timeIntervalSince1970, forKey: "date")
+        motionMO.setValue(domain.type.rawValue, forKey: "type")
+        motionMO.setValue(domain.time, forKey: "time")
+        motionMO.setValue(domain.data.x, forKey: "x")
+        motionMO.setValue(domain.data.y, forKey: "y")
+        motionMO.setValue(domain.data.z, forKey: "z")
+        
+        try context.save()
     }
     
     func read(from offset: Int) throws -> [MotionMO] {

--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -9,6 +9,7 @@ import CoreData
 
 enum CoreDataError: Error {
     case invalidEntity
+    case invalidID
 }
 
 struct DefaultCoreDataRepository: CoreDataRepository {
@@ -51,14 +52,21 @@ struct DefaultCoreDataRepository: CoreDataRepository {
     }
     
     func read(from offset: Int) throws -> [MotionMO] {
-        return []
-    }
-    
-    func read(with id: String) throws -> MotionMO {
-        return MotionMO(context: context)
+        let request = MotionMO.fetchRequest()
+        request.fetchOffset = offset
+        request.fetchLimit = offset + 9
+        
+        let result = try context.fetch(request)
+        return result
     }
     
     func delete(_ id: String) throws {
+        let request = MotionMO.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id)
         
+        guard let target = try context.fetch(request).first else { throw CoreDataError.invalidID }
+        context.delete(target)
+        
+        try context.save()
     }
 }

--- a/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
@@ -6,5 +6,10 @@
 //
 
 protocol CoreDataRepository {
+    associatedtype Domain: Identifiable
+    associatedtype Entity: Identifiable
     
+    func create(_ entity: Entity) throws
+    func read(from offset: Int) throws -> [Entity]
+    func delete(_ id: String) throws
 }

--- a/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
@@ -9,7 +9,7 @@ protocol CoreDataRepository {
     associatedtype Domain: Identifiable
     associatedtype Entity: Identifiable
     
-    func create(_ entity: Entity) throws
+    func create(_ domain: Domain) throws
     func read(from offset: Int) throws -> [Entity]
     func delete(_ id: String) throws
 }


### PR DESCRIPTION
- CoreDataRepository Protocol 구현
- DefaultCoreDataRepository 구현
- CoreDataError 열거형 구현
- DefaultCoreDataRepository가 CoreDataRepository프로토콜 채택
- CoreDataRepository프로토콜 요구사항 구현

### 체크사항
- CoreDataError에 invalidEntity, invalidID 두가지 케이스가 있습니다.
    - invalidEntity는 엔티티 로드가 실패할 때 던져지고
    - invalidID는 delete메서드에서 일치하는 id가 없을 때 던져집니다.
