### PR TITLE
Default Core Data Repository 리팩토링

### DIFF
--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -12,7 +12,7 @@ enum CoreDataError: Error {
     case invalidID
 }
 
-struct DefaultCoreDataRepository: CoreDataRepository {
+final class DefaultCoreDataRepository: CoreDataRepository {
     typealias Domain = Motion
     typealias Entity = MotionMO
     
@@ -29,30 +29,37 @@ struct DefaultCoreDataRepository: CoreDataRepository {
     private let context: NSManagedObjectContext
     
     init() {
-        let context = persistentContainer.viewContext
+        let context = persistentContainer.newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
         self.context = context
     }
     
-    func create(_ domain: Motion) throws {
-        guard let entity = NSEntityDescription.entity(
-            forEntityName: "MotionMO",
-            in: context
-        ) else {
-            throw CoreDataError.invalidEntity
+    func create(_ domain: Motion, completion: @escaping (Result<MotionMO, Error>) -> Void) {
+        context.perform {
+            guard let entity = NSEntityDescription.entity(
+                forEntityName: "MotionMO",
+                in: self.context
+            ) else {
+                return completion(.failure(CoreDataError.invalidEntity))
+            }
+            
+            let motionMO = MotionMO(entity: entity, insertInto: self.context)
+            
+            motionMO.setValue(domain.id, forKey: "id")
+            motionMO.setValue(domain.date.timeIntervalSince1970, forKey: "date")
+            motionMO.setValue(domain.type.rawValue, forKey: "type")
+            motionMO.setValue(domain.time, forKey: "time")
+            motionMO.setValue(domain.data.x, forKey: "x")
+            motionMO.setValue(domain.data.y, forKey: "y")
+            motionMO.setValue(domain.data.z, forKey: "z")
+            
+            do {
+                try self.context.save()
+            } catch {
+                completion(.failure(error))
+            }
+            completion(.success(motionMO))
         }
-        
-        let motionMO = NSManagedObject(entity: entity, insertInto: context)
-        
-        motionMO.setValue(domain.id, forKey: "id")
-        motionMO.setValue(domain.date.timeIntervalSince1970, forKey: "date")
-        motionMO.setValue(domain.type.rawValue, forKey: "type")
-        motionMO.setValue(domain.time, forKey: "time")
-        motionMO.setValue(domain.data.x, forKey: "x")
-        motionMO.setValue(domain.data.y, forKey: "y")
-        motionMO.setValue(domain.data.z, forKey: "z")
-        
-        try context.save()
     }
     
     func read(from offset: Int) throws -> [MotionMO] {

--- a/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/DefaultCoreDataRepository.swift
@@ -12,7 +12,7 @@ enum CoreDataError: Error {
     case invalidID
 }
 
-final class DefaultCoreDataRepository: CoreDataRepository {
+struct DefaultCoreDataRepository: CoreDataRepository {
     typealias Domain = Motion
     typealias Entity = MotionMO
     

--- a/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
+++ b/GyroData/Repository/CoreData/Protocol/CoreDataRepository.swift
@@ -9,7 +9,7 @@ protocol CoreDataRepository {
     associatedtype Domain: Identifiable
     associatedtype Entity: Identifiable
     
-    func create(_ domain: Domain) throws
+    func create(_ domain: Domain, completion: @escaping (Result<Entity, Error>) -> Void)
     func read(from offset: Int) throws -> [Entity]
     func delete(_ id: String) throws
 }


### PR DESCRIPTION
- CoreDataRepository Protocol 요구사항 리팩토링
- DefaultCoreDataRepository create 메서드 비동기 구현

### 체크사항
- 비동기 처리를 위해 context를 백그라운드 컨텍스트로 변경하였습니다.
- 컨텍스트를 초기화 하는 방법으로 이니셜라이저를 통해 newBackgroundContext() 메서드를 호출하도록 하였습니다.